### PR TITLE
질문 데이터 전체 리덕스 설정, API 요청 후 데이터 화면에 뿌려주기

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -13,6 +13,8 @@ import { useEffect } from "react";
 
 import Editor from "ckeditor5-custom-build/build/ckeditor";
 import { CKEditor } from "@ckeditor/ckeditor5-react"; // import가 반드시 한 곳에서만 일어나야함, 만약 detail페이지에서도 쓸것이라면 좀 더 공통 상위의 코드에서 props로 각각 내려볼 수도 있을것임
+import { getQuestionsService } from "./services/questionDataServices";
+import { getQuestionsListActon } from "./redux/actions/questionListAction";
 
 function App() {
 	const dispatch = useDispatch();
@@ -24,11 +26,15 @@ function App() {
 	};
 
 	useEffect(() => {
+		getQuestionsService().then((res)=>{
+			dispatch(getQuestionsListActon(res));
+		});
+
 		window.addEventListener("resize", handleDeviceWidthResize);
 		return () => {
 			window.removeEventListener("resize", handleDeviceWidthResize);
 		};
-	});
+	},[]);
 
 	return (
 		<BrowserRouter>

--- a/client/src/components/Question.js
+++ b/client/src/components/Question.js
@@ -40,20 +40,16 @@ export default function Question({ item }) {
 				{showCurrent && (
 					<Current>
 						<div>1 {/* item.answer.length */} Answers</div>
-						<div>6 {/* item.views */} views</div>
+						<div>{ item.viewCount } views</div>
 					</Current>
 				)}
 				<Container>
 					<Contents>
 						<h1>
-							Camera plugin in flutter making callback after taking picture
-							{/* item.title */}
+							{item.title}
 						</h1>
 						<div>
-							I am trying to capture image using camera in flutter. Image should
-							be captured, for that using takePicture method. I am understanding
-							whether the image is capturing or not, in debug, I got ...
-							{/* item.content.slice(0, 100) */}
+							{ item.content }
 						</div>
 					</Contents>
 					<Info>

--- a/client/src/pages/MainPage.js
+++ b/client/src/pages/MainPage.js
@@ -21,7 +21,7 @@ export const MainSmallNavigator = styled.section`
 `
 const MainPage = () => {
 	const questions = useSelector((state)=>state.questionListReducer);
-
+	console.log(questions);
 	return (
 	// 렌더링 테스트를 위해 임시로 적용해 두었습니다! 필요시 삭제 부탁드립니다.
 	<MainPageContainer>
@@ -29,7 +29,7 @@ const MainPage = () => {
 			<SmallLinkButtonDesign to='/write' color={globalTokens.pointColor.value}>질문 쓰기</SmallLinkButtonDesign>
 		</MainSmallNavigator>
 		{
-			questions.length>0? questions.map((e)=><Question/>):null
+			questions.length>0? questions.map((e)=><Question item={e}/>):null
 		}
 	</MainPageContainer>
 	);

--- a/client/src/pages/MainPage.js
+++ b/client/src/pages/MainPage.js
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Question from "../components/Question";
 import { Link } from "react-router-dom";
 import { styled } from "styled-components";
 import tokens from '../styles/tokens.json'
 import { SmallLinkButtonDesign } from "../atoms/Button";
+import { useSelector } from "react-redux";
 
 const globalTokens = tokens.global;
 
@@ -19,19 +20,17 @@ export const MainSmallNavigator = styled.section`
 	justify-content: end;
 `
 const MainPage = () => {
+	const questions = useSelector((state)=>state.questionListReducer);
+
 	return (
 	// 렌더링 테스트를 위해 임시로 적용해 두었습니다! 필요시 삭제 부탁드립니다.
 	<MainPageContainer>
 		<MainSmallNavigator>
 			<SmallLinkButtonDesign to='/write' color={globalTokens.pointColor.value}>질문 쓰기</SmallLinkButtonDesign>
 		</MainSmallNavigator>
-		<Link to="/detail" 
-			style={{
-				display: "flex",
-				justifyContent: "center",
-				alignItems: "center"}}>
-			<Question />
-		</Link>
+		{
+			questions.length>0? questions.map((e)=><Question/>):null
+		}
 	</MainPageContainer>
 	);
 };

--- a/client/src/redux/actions/questionListAction.js
+++ b/client/src/redux/actions/questionListAction.js
@@ -1,0 +1,8 @@
+export const GET_QUESTIONS_LIST = 'GET_QUESTIONS_LIST'
+
+export const getQuestionsListActon = (questionsList) => {
+    return {
+        type: GET_QUESTIONS_LIST,
+        payload: questionsList,
+    }
+}

--- a/client/src/redux/reducers/index.js
+++ b/client/src/redux/reducers/index.js
@@ -1,10 +1,12 @@
 import { combineReducers } from "redux";
 import { authReducer } from "./authReducer";
 import { browserWidthReducer } from './browserWidthReducer';
+import { questionListReducer } from './questionListReducer';
 
 const rootReducer = combineReducers({
     browserWidthReducer,
     authReducer,
+    questionListReducer
 })
 
 export default rootReducer;

--- a/client/src/redux/reducers/index.js
+++ b/client/src/redux/reducers/index.js
@@ -6,7 +6,7 @@ import { questionListReducer } from './questionListReducer';
 const rootReducer = combineReducers({
     browserWidthReducer,
     authReducer,
-    questionListReducer
+    questionListReducer,
 })
 
 export default rootReducer;

--- a/client/src/redux/reducers/questionListReducer.js
+++ b/client/src/redux/reducers/questionListReducer.js
@@ -1,0 +1,11 @@
+import { GET_QUESTIONS_LIST } from "../actions/questionListAction";
+
+const initialState = [];
+
+export const questionListReducer = (state=initialState, action) => {
+    switch(action.type) {
+        case GET_QUESTIONS_LIST: 
+            return action.payload;
+        default: return state;
+    }
+}

--- a/client/src/services/questionDataServices.js
+++ b/client/src/services/questionDataServices.js
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+//전체 질문 목록을 조회하는 메소드
+export const getQuestionsService = async () => {
+	let response = await axios.get(`http://ec2-3-34-134-76.ap-northeast-2.compute.amazonaws.com:8080/questions?page=1&size=10`);
+	return response.data;
+}


### PR DESCRIPTION
질문 데이터 전체 리덕스 설정, API 요청 후 데이터 화면에 뿌려주기

1. App.js의 useEffect에서 services/questionDataServices.js의 ```getQuestionsService``` 메소드 실행 후, questionListReducer state를 dispatch 한다.
2. MainPage.js에서 useSelector을 이용해 state를 가져온 다음, state의 값을 ```questions.map((e)=><Question item={e}/>)``` 해준다. 
<img src="https://github.com/codestates-seb/seb45_pre_004/assets/50258232/a4c2440c-d580-4eb1-9a18-107d739b32d8" width="600px"/>
