### PR TITLE
로그인, 회원가입 페이지에서 Navigator 안나오게 설정

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,6 +16,7 @@ import { CKEditor } from "@ckeditor/ckeditor5-react"; // import가 반드시 한
 function App() {
 	const dispatch = useDispatch();
 	const deviceWidth = useSelector((state) => state.browserWidthReducer);
+	const location = useSelector((state)=>state.locationReducer);
 
 	useEffect(() => {
 		//브라우저의 너비가 바뀔 때 실행되는 메소드
@@ -27,7 +28,7 @@ function App() {
 			window.removeEventListener("resize", handleDeviceWidthResize);
 		};
 	}, [dispatch]);
-
+	console.log(location)
 	return (
 		<BrowserRouter>
 			<Header />
@@ -45,7 +46,7 @@ function App() {
 					element={<QnADetailPage Editor={Editor} CKEditor={CKEditor} />}
 				/>
 			</Routes>
-			{deviceWidth > 800 ? <Navigator /> : null}
+			{deviceWidth > 800 && location!=='/login' && location!=='/signup'? <Navigator /> : null}
 			<Footer />
 		</BrowserRouter>
 	);

--- a/client/src/components/Navigator.js
+++ b/client/src/components/Navigator.js
@@ -1,15 +1,22 @@
 import { useState, useEffect } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import logoImg from "../assets/images/logoImage.png";
 import Nav from "../styles/navigator";
 import { SmallCircleButtonDesign as Button } from "../atoms/Button";
 import tokens from "../styles/tokens.json";
+import { removeUserInfo } from "../redux/actions/userInfoAction";
+import { setIsLoginFalse } from "../redux/actions/isLoginAction";
 
 const Navigator = () => {
+	const dispatch = useDispatch();
 	const isLogin = useSelector((state) => state.isLoginReducer);
 	const [showNavigator, setShowNavigator] = useState(false);
 
+	const logoutClickHandler = () => {
+		dispatch(removeUserInfo());
+		dispatch(setIsLoginFalse());
+	}
 	useEffect(() => {
 		const handleScroll = () => {
 			const shouldShow = window.scrollY > 150;
@@ -33,9 +40,10 @@ const Navigator = () => {
 					<img src={logoImg} alt="Logo" />
 				</Link>
 				{isLogin ? (
-					<Link to="/" onClick={()=>console.log('isClicked')}>
-						<Button color={tokens.global.whiteColor.value} fontColor={tokens.global.pointColor.value}>로그아웃</Button>
-					</Link>
+					<Button 
+						color={tokens.global.whiteColor.value} 
+						fontColor={tokens.global.pointColor.value}
+						onClick={logoutClickHandler}>로그아웃</Button>
 				) : (
 					<div>
 						<Link to="/login">

--- a/client/src/pages/LoginPage.js
+++ b/client/src/pages/LoginPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setIsLoginTrue } from "../redux/actions/isLoginAction";
 import { LoginInputBottomDesign, LoginInputTopDesign } from "../atoms/Input";
@@ -6,10 +6,11 @@ import tokens from '../styles/tokens.json'
 import { TextButtonDesign } from "../atoms/Button";
 import { LoginButton, LoginContainer, LoginForm, LoginPageContainer, LoginTitle, WarningSpan } from "../styles/loginPageStyle";
 import { loginService } from "../services/loginServices";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { setUserInfo } from "../redux/actions/userInfoAction";
 import { closeModalAction, openModalAction } from "../redux/actions/isModalOpenAction";
 import { ModalBackdrop, ModalButton, ModalContainer, ModalText } from "../components/Modal";
+import { setLocation } from "../redux/actions/locationAction";
 const globalTokens = tokens.global;
 
 
@@ -17,9 +18,14 @@ const LoginPage = () => {
 	const isModalOpen = useSelector((state)=>state.isModalOpenReducer);
 	const navigate = useNavigate();
 	const dispatch = useDispatch();
+	const location = useLocation().pathname;
 	const [ inputId, setInputId ] = useState('');
 	const [ inputPassword, setInputPassword ] = useState('');
 	const [ warningText, setWarningText ] = useState('');
+
+	useMemo(()=>{
+		dispatch(setLocation(location));
+	},[]);
 
 	const onInputIdChange = (e) => {
 		setInputId(e.target.value);

--- a/client/src/pages/MainPage.js
+++ b/client/src/pages/MainPage.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import Pagination from "react-js-pagination";
 import { getQuestionsService } from "../services/questionDataServices";
 import Question from "../components/Question";
@@ -24,6 +24,7 @@ import {
 	openModalAction,
 } from "../redux/actions/isModalOpenAction";
 import tokens from "../styles/tokens.json";
+import { setLocation } from "../redux/actions/locationAction";
 
 const globalTokens = tokens.global;
 
@@ -33,6 +34,7 @@ const MainPage = () => {
 	//isLogin state, userInfo redux state 조회
 	const isLogin = useSelector((state) => state.isLoginReducer);
 	const navigate = useNavigate();
+	const location = useLocation().pathname;
 	const [activePage, setActivePage] = useState(1);
 	const [questions, setQuestions] = useState([]);
 	const [totalItems, setTotalItems] = useState(1);
@@ -56,6 +58,10 @@ const MainPage = () => {
 	const modalButtonClickHandler = () => {
 		navigate("/login");
 	};
+
+	useMemo(()=>{
+		dispatch(setLocation(location));
+	},[])
 
 	useEffect(() => {
 		const fetchQuestions = async () => {

--- a/client/src/pages/QnADetailPage.js
+++ b/client/src/pages/QnADetailPage.js
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
 import parse from "html-react-parser";
 import Prism from "prismjs";
 import "prismjs/themes/prism.css";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import DateDistance from "../components/DateDistance";
 import {
@@ -25,10 +25,12 @@ import {
 	SubmitButton,
 	ContentBox,
 } from "../styles/qnaDetail";
+import { setLocation } from "../redux/actions/locationAction";
 
 const QnADetailPage = ({ Editor, CKEditor }) => {
 	let params = useParams();
-
+	let location = useLocation().pathname;
+	let dispatch = useDispatch();
 	const userInfo = useSelector((state) => state.userInfoReducer);
 	const [editMode, setEditMode] = useState(false);
 	const [content, setContent] = useState("");
@@ -67,6 +69,10 @@ const QnADetailPage = ({ Editor, CKEditor }) => {
 			{ headers: { Authorization: token } }
 		);
 	};
+ 	//현재 라우터 정보를 location redux로 관리
+	useMemo(()=>{
+		dispatch(setLocation(location));
+	})
 
 	useEffect(() => {
 		async function getDetailInfo() {

--- a/client/src/pages/QnAWritePage.js
+++ b/client/src/pages/QnAWritePage.js
@@ -1,7 +1,6 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import axios from "axios";
-
 import {
   QnAWritePageContainer,
   QnAWriteInfoContainer,
@@ -14,18 +13,21 @@ import {
   Warning,
   DisabledButton,
 } from "../styles/qnaWrite";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { setLocation } from "../redux/actions/locationAction";
 
 const QnAWritePage = ({ Editor, CKEditor }) => {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const location = useLocation().pathname;
   const userInfo = useSelector((state) => state.userInfoReducer);
 
   const onChangeTitleHandler = (e) => {
     setTitle(e.target.value);
   };
-
+  
   const onSubmitHandler = async (e) => {
     e.preventDefault();
     const token = userInfo.token;
@@ -44,6 +46,10 @@ const QnAWritePage = ({ Editor, CKEditor }) => {
     const id = data.data["questionId"]; // 받은 아이디를 통해 페이지로 네비게이트 시킴
     navigate(`/detail/${id}`);
   };
+
+  useMemo(()=>{
+    dispatch(setLocation(location));
+  },[])
 
   return (
     <QnAWritePageContainer>

--- a/client/src/pages/SignupPage.js
+++ b/client/src/pages/SignupPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { SignUpPageContainer, SignUpContainer, Input, InputAndLabelBox, InputLabel, SignUpButton, WarningSpan, SignupHeading, SignupPageModalBackdrop, SignupPageModalContainer, SignupPageModalText, SignupPageModalButton } from "../styles/signupPageStyle";
 
 import { signupService } from "../services/loginServices";
@@ -7,11 +7,14 @@ import { closeModalAction, openModalAction } from "../redux/actions/isModalOpenA
 
 import tokens from '../styles/tokens.json'
 import { ModalBackdrop, ModalContainer, ModalText, ModalButton } from "../components/Modal";
+import { useLocation } from "react-router-dom";
+import { setLocation } from "../redux/actions/locationAction";
 const globalTokens = tokens.global;
 
 const SignupPage = () => {
   const isModalOpen = useSelector((state)=>state.isModalOpenReducer);
   const dispatch = useDispatch();
+  const location = useLocation().pathname;
 
   const [name, setName] = useState("");
   const [id, setId] = useState("");
@@ -23,6 +26,10 @@ const SignupPage = () => {
   const [passwordCheckWarningText, setPasswordCheckWarningText] = useState("");
   const [modalCategory, setModalCategory] = useState("");
 
+  //현재 라우터 정보를 location redux로 관리
+  useMemo(()=>{
+    dispatch(setLocation(location));
+  },[])
   const onChangeNameHandler = (e) => {
     let nameInput = e.target.value;
     setNameWarningText('');
@@ -68,6 +75,7 @@ const SignupPage = () => {
         dispatch(openModalAction());
       }
     }
+  //회원가입 버튼 클릭 시 동작
   const onSignupButtonClickHandler = (e) => {
     if(!name) {
       setNameWarningText('이름을 입력해 주세요!');
@@ -90,10 +98,12 @@ const SignupPage = () => {
       signUp();
     }
   }
+  //가입성공 모달창의 '로그인하기'버튼 클릭 시 동작
   const onLoginButtonClickListener = (e) => {
     //로그인 화면으로 이동 후 팝업창 닫음 (Link 태그라서 팝업창만 닫으면 됨)
     dispatch(closeModalAction());
   }
+  //가입 실패 모달창의 '확인'버튼 클릭 시 동작
   const errorModalButtonHandler = (e) => {
     dispatch(closeModalAction());
   }

--- a/client/src/redux/actions/locationAction.js
+++ b/client/src/redux/actions/locationAction.js
@@ -1,0 +1,8 @@
+export const SET_LOCATION = "SET_LOCATION";
+
+export function setLocation (location) {
+    return { 
+        type: SET_LOCATION, 
+        payload: location
+    }
+}

--- a/client/src/redux/reducers/index.js
+++ b/client/src/redux/reducers/index.js
@@ -3,12 +3,14 @@ import { isLoginReducer } from "./isLoginReducer";
 import { userInfoReducer } from "./userInfoReducer";
 import { browserWidthReducer } from './browserWidthReducer';
 import { isModalOpenReducer } from './isModalOpenReducer';
+import { locationReducer } from './locationReducer';
 
 const rootReducer = combineReducers({
     browserWidthReducer,
     isLoginReducer,
     userInfoReducer,
     isModalOpenReducer,
-})
+    locationReducer,
+});
 
 export default rootReducer;

--- a/client/src/redux/reducers/locationReducer.js
+++ b/client/src/redux/reducers/locationReducer.js
@@ -1,0 +1,11 @@
+import { SET_LOCATION } from "../actions/locationAction";
+
+const initialState = '/';
+
+export const locationReducer = (state = initialState, action) => {
+    switch (action.type) {
+        case SET_LOCATION :
+             return action.payload;
+        default : return state;
+    }
+}


### PR DESCRIPTION
로그인, 회원가입 페이지에서 Navigator 안나오게 설정

### 구현 방법 
1. 모든 Route 경로에서 useLocation으로 현재 라우터 정보를 구한다. 
2. redux로 현재 라우터 정보를 전역 state로 관리한다.
3. App.js에서 redux state를 참조해서 login, signup 페이지일 경우 Navigator를 보여주지 않는다. 